### PR TITLE
Replace t411.me with t411.io

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,7 +10,7 @@ config = [{
             'tab': 'searcher',
             'list': 'torrent_providers',
             'name': 't411',
-            'description': 'See <a href="https://www.t411.me/">T411</a>',
+            'description': 'See <a href="https://www.t411.io/">T411</a>',
             'wizard': True,
             'options': [
                 {

--- a/__init__.py
+++ b/__init__.py
@@ -11,6 +11,7 @@ config = [{
             'list': 'torrent_providers',
             'name': 't411',
             'description': 'See <a href="https://www.t411.io/">T411</a>',
+            'icon': 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAc5JREFUOI3tkk9IU3EAxz/vrbWeb+/NNdtmBS5kEHWwYfYHKulWCbtIh4i8JAYN6pRReKwMiooOElEGYkllUIgVTBhZRGHRKnBbaeGyOf+smshLeO/56xCMvHcJ+ty+l8/h+/3Cf6Q/w4VPYtvrkZk2c/DRzlQmbc3ajiKKnvvpC05MBcIfWb/5PTJ9RKWZRYJoUkRS77Ld+eL8Os/YMOM3z8PEKI1HY0xNFngaH6KuPsKHOShaNljSArUNLVxsuP5bc3zwTfuDpKB2n6CpQ0C12NIYE32js6L9dkK0nOkUL6dtUVW3W1xKpMX+1rOCrbEXADLAhuzA2ubtIfaEVDBtwMmRE8foudFNua5x9VQXd/oHKFNU4re6WOHR4cd0uCRI9vRa8VfDPLx3DZxOmtoO4xSCTRtrUL1eMDIEdRVddaNrOj6tDITDLAmg8DZvLyN66CQ4ZNLjBRLPhviay2MYBlBBld+Dx1OOoigskSQIrMyUStz7WKh3Tzf3OueKu8yaerBMiN+nsno1a1b5eZ7Konl9GO7laEtdVLqVsW8uf2yy82D/ohlb04LL5zquzAfDO8h/XkB2fEd25fAGvqBWpAhFnnBAGvm7T/r3+QVQzKvI28pwFwAAAABJRU5ErkJggg==',
             'wizard': True,
             'options': [
                 {

--- a/main.py
+++ b/main.py
@@ -12,12 +12,12 @@ log = CPLog(__name__)
 class t411(TorrentProvider, MovieProvider):
 
     urls = {
-        'test' : 'https://www.t411.me',
-        'login' : 'https://www.t411.me/users/login/',
-        'login_check': 'https://www.t411.me',
-        'detail': 'https://www.t411.me/torrents/?id=%s',
-        'search': 'https://www.t411.me/torrents/search/?search=%s %s',
-        'download' : 'http://www.t411.me/torrents/download/?id=%s',
+        'test' : 'https://www.t411.io',
+        'login' : 'https://www.t411.io/users/login/',
+        'login_check': 'https://www.t411.io',
+        'detail': 'https://www.t411.io/torrents/?id=%s',
+        'search': 'https://www.t411.io/torrents/search/?search=%s %s',
+        'download' : 'http://www.t411.io/torrents/download/?id=%s',
     }
 
     http_time_between_calls = 1 #seconds


### PR DESCRIPTION
t411.me is now available at t411.io

I also added the icon (it's base 64 encoded, tested and working).
