### PR TITLE
Une nouvelle fonctionnalité pour le plugin

### DIFF
--- a/t411/allocine.py
+++ b/t411/allocine.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+"""
+A module to use Allocine API V3 in Python
+Base on work from: http://wiki.gromez.fr/dev/api/allocine_v3
+Forked from : https://github.com/xbgmsharp/allocine (by Francois Lacroix)
+License : GPL
+
+Sample code:
+
+    from allocine import allocine
+    api = allocine()
+    search = api.search("Harry Potter")
+
+"""
+
+from datetime import date
+import urllib2, urllib
+import hashlib, base64
+import json
+
+__description__ = "A module to use Allocine API V3 in Python"
+
+class allocine(object):
+    """An interface to the Allocine API"""
+    def __init__(self):
+        """Init values"""
+        self._api_url = 'http://api.allocine.fr/rest/v3'
+        self._partner_key  = 'aXBob25lLXYy'
+        self._secret_key = '29d185d98c984a359e6e6f26a0474269'
+        self._user_agent = 'AlloCine/2.9.5 CFNetwork/548.1.4 Darwin/11.0.0'
+
+    def _do_request(self, params=None):
+        """Generate and send the request"""
+        # build the URL
+        query_url = self._api_url+'/search';
+
+        # create signature to ask allocine api
+        sed = date.today().strftime('%Y%m%d')
+        sha1 = hashlib.sha1(self._secret_key+urllib.urlencode(params)+'&sed='+sed).digest()
+        sig = urllib2.quote(base64.b64encode(sha1))
+
+        query_url += '?'+urllib.urlencode(params)+'&sed='+sed+'&sig='+sig
+
+        # do the request
+        req = urllib2.Request(query_url)
+        req.add_header('User-agent', self._user_agent)
+
+        response = json.load(urllib2.urlopen(req, timeout = 6))
+
+        return response;
+    
+    def search(self, query):
+        """Search for a term
+        Param:
+            query -- Term to search for
+        """
+        # build the params
+        params = {}
+        params['format'] = 'json'
+        params['partner'] = self._partner_key
+        params['q'] = query
+        params['filter'] = "movie"
+
+        # do the request
+        response = self._do_request(params);
+
+        return response;

--- a/t411/main.py
+++ b/t411/main.py
@@ -182,12 +182,14 @@ def acceptableQualityTerms(quality):
     alternatives = quality.get('alternative', [])
     # first acceptable term is the identifier itself
     acceptableTerms = [quality['identifier']]
+    log.debug('Requesting alternative quality terms for : ' + str(acceptableTerms) )
     # handle single terms
     acceptableTerms.extend([ term for term in alternatives if type(term) == type('') ])
     # handle doubled terms (such as 'dvd rip')
     doubledTerms = [ term for term in alternatives if type(term) == type(('', '')) ]
     acceptableTerms.extend([ '('+first+'%26'+second+')' for (first,second) in doubledTerms ])
     # join everything and return
+    log.debug('Found alternative quality terms : ' + str(acceptableTerms).replace('%26', ' '))
     return '|'.join(acceptableTerms)
 
 def getFrenchTitle(title):
@@ -203,6 +205,7 @@ def getFrenchTitle(title):
 
     # open the api and create the request
     api = allocine()
+    log.debug('Looking for French title of : ' + title)
     try:
         search = api.search(title)
     except urllib2.HTTPError:
@@ -213,6 +216,7 @@ def getFrenchTitle(title):
 
     # check if there is a result
     if 'movie' not in search['feed'].keys():
+        log.debug('Allocine could not find a movie corresponding to : ' + title)
         return None
 
     # if there is a result, extract first result
@@ -227,8 +231,10 @@ def getFrenchTitle(title):
         
     # Then, we check if the new title is the same as the given one. If not, return it
     if (title == newTitle):
+        log.debug('Allocine API found the movie but it is the same title.')
         return None
     else:
+        log.debug('Allocine API found the french title : ' + newTitle)
         return newTitle
 
 def replaceTitle(releaseNameI, titleI, newTitleI):
@@ -245,6 +251,7 @@ def replaceTitle(releaseNameI, titleI, newTitleI):
     if newTitle is None: # if the newTitle is empty, do nothing
         return releaseNameI
     else:
+        log.debug('Replacing -- ' + newTitle + ' -- in the release -- ' + releaseName + ' -- by the original title -- ' + title)
         separatedWords = []
         for s in releaseName.split(' '):
             separatedWords.extend(s.split('.'))
@@ -259,10 +266,12 @@ def replaceTitle(releaseNameI, titleI, newTitleI):
         # then determine if it correspoinds to the new title or old title
         if index >= newIndex:
             # the release name corresponds to the original title. SO no change needed
+            log.debug('The release name is already corresponding. Changed nothing.')
             return releaseNameI
         else:
             # otherwise, we replace the french title by the original title
             finalName = [title]
             finalName.extend(separatedWords[newIndex:])
             newReleaseName = ' '.join(finalName)
+            log.debug('The new release name is : ' + newReleaseName)
             return newReleaseName

--- a/t411/main.py
+++ b/t411/main.py
@@ -63,8 +63,15 @@ class t411(TorrentProvider, MovieProvider):
     def _searchOnTitle(self, title, movie, quality, results):
 
         log.debug('Searching T411 for %s' % (title))
+        # test the new title and search for it if valid
+        newTitle = getFrenchTitle(title)
+        request = ''
+        if newTitle is not None:
+            request = ('(' + title + ')|(' + newTitle + ')').replace(':', '')
+        else:
+            request = title.replace(':', '')
 
-        url = self.urls['search'] % (title.replace(':', ''), acceptableQualityTerms(quality))
+        url = self.urls['search'] % (request, acceptableQualityTerms(quality))
         data = self.getHTMLData(url)
 
         log.debug('Received data from T411')
@@ -95,7 +102,7 @@ class t411(TorrentProvider, MovieProvider):
                     age = result.findAll('td')[4].text
                     results.append({
                         'id': idt,
-                        'name': release_name,
+                        'name': replaceTitle(release_name, title, newTitle),
                         'url': self.urls['download'] % idt,
                         'detail_url': self.urls['detail'] % idt,
                         'size': self.parseSize(str(result.findAll('td')[5].text)),

--- a/t411/main.py
+++ b/t411/main.py
@@ -223,3 +223,39 @@ def getFrenchTitle(title):
         return None
     else:
         return newTitle
+
+def replaceTitle(releaseNameI, titleI, newTitleI):
+    """
+    This function is replacing the title in the release name by the old one,
+    so that couchpotato recognise it as a valid release.
+    """
+    
+    # input as lower case
+    releaseName = releaseNameI.lower()
+    title = titleI.lower()
+    newTitle = newTitleI.lower()
+
+    if newTitle is None: # if the newTitle is empty, do nothing
+        return releaseNameI
+    else:
+        separatedWords = []
+        for s in releaseName.split(' '):
+            separatedWords.extend(s.split('.'))
+        # test how far the release name corresponds to the original title
+        index = 0
+        while separatedWords[index] in title.split(' '):
+            index += 1
+        # test how far the release name corresponds to the new title
+        newIndex = 0
+        while separatedWords[newIndex] in newTitle.split(' '):
+            newIndex += 1
+        # then determine if it correspoinds to the new title or old title
+        if index >= newIndex:
+            # the release name corresponds to the original title. SO no change needed
+            return releaseNameI
+        else:
+            # otherwise, we replace the french title by the original title
+            finalName = [title]
+            finalName.extend(separatedWords[newIndex:])
+            newReleaseName = ' '.join(finalName)
+            return newReleaseName


### PR DESCRIPTION
Bonjour !

Alors voilà, je me suis rendu compte en utilisant le plugin que la plupart des torrents sur t411 utilisent les noms français des films.
Du coup, pas moyen de dire à couchpotato, recherche 'A walk among the tombstones' (par exemple) sur un tracker anglais et t411 en même temps : soit on choisit le nom français et on aura des résultats seulement sur t411, soit on choisis le nom original et on aura des résultats sur les autres trackers (et avec un peu de chances, quelques résultats sur t411).

Voici donc la solution que j'ai trouvé : 
On choisit toujours le titre original du film. 
Puis, on utilise l'API d'Allocine pour récupérer le titre français. 
Ensuite, on fait la recherche sur t411 avec le titre original et le titre français.
Avant de retourner les résultats à couchpotato, on remplace le titre français dans les noms des releases par le titre original, comme ça couchpotato ne rejette pas la release.

Et voilà :-) 
Bien sûr, je me suis arrangé pour que les erreurs à tous les niveaux (pas de connexions à Allociné, pas de titre trouvé, etc) soient rattrapées et que le programme fonctionne correctement.
J'ai testé sur 5 films pour l'instant, je verrais à l'usage s'il y a d'autres améliorations à faire.

A plus
